### PR TITLE
#3 Add promise rejection on null result Android

### DIFF
--- a/src/geocoding.android.ts
+++ b/src/geocoding.android.ts
@@ -8,6 +8,9 @@ export function getLocationFromName(searchString: string): Promise<Location> {
         if (locations != null && locations.size() > 0) {
             let loc = locations.get(0);
             return resolve(new Location(loc));
+        } else {
+            let androidError = new Error('Android Geocoder error : No locations found');
+            reject(androidError);
         }
     });
 }
@@ -26,6 +29,9 @@ export function getLocationListFromName(searchString: string, maxResCount?: numb
                 res.push(new Location(locations.get(i)));
             }
             return resolve(res);
+        } else {
+            let androidError = new Error('Android Geocoder error : No locations found');
+            reject(androidError);
         }
     });
 }


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
When no result is found on Android the promise never resolves/rejects. See #3 

## What is the new behavior?
When Android Geocoder returns null the promise rejects similarly to iOS with an error stating 'No locations found'.

Fixes/Implements/Closes #3 .